### PR TITLE
Show notification with keystore location instead alert

### DIFF
--- a/interface/elements/msc-profile-view/msc-profile-view.js
+++ b/interface/elements/msc-profile-view/msc-profile-view.js
@@ -71,7 +71,13 @@ Polymer({
       } else if (platform.includes("linux")){ //linux
         var pathOfKey = '/' + username1 + '/.musicoin/keystore';
       }
-      alert("Please Backup your key in a safe place to avoid it from being stolen. If your key is stolen, there is NO WAY to retrieve your lost funds.");
+      var iconPath = 'file://' + nw.__dirname + '/favicon.png';
+      var alert = {
+        icon: iconPath,
+        body: "Please backup your key in a safe place to avoid it from being stolen. Otherwise, there is NO WAY to retrieve your lost funds." +
+        " You can locate your keys in: \n" + pathOfKey + " directory."
+};
+      new Notification("Please backup your key", alert);
       gui.Shell.showItemInFolder(pathOfKey);
     });
   },


### PR DESCRIPTION
Alert takes focus, more above in case user use not default filemanager, alert will be the only thing user will see.
But sadly, there no good alternative to `gui.Shell.showItemInFolder(pathOfKey);` and with it i didn't see filemanager with opened keystore location, since I use pcmanfm.
So my suggestion is to show alert, with keystore path, which didn't take focus, and in case user use custom filemanager and `showItemInFolder` not working, user will be able at least to see keystore path, and backup manually.
![ex-music-notify](https://user-images.githubusercontent.com/6484506/33177650-4d52fc26-d05b-11e7-92de-865453ce2cc2.png)