### PR TITLE
Fix for an issue #45 and backup dialog under Linux

### DIFF
--- a/interface/elements/msc-profile-view/msc-profile-view.html
+++ b/interface/elements/msc-profile-view/msc-profile-view.html
@@ -20,7 +20,8 @@
 
     <div class="buttons-style">
     <paper-button raised on-tap="handleNewAccount" id="new-account">NEW ACCOUNT</paper-button>
-    <paper-button raised on-tap="handleSetCustomCoinbase" id="old-wallet">ADD EXISTING ACCOUNT</paper-button>
+    <input id="fileDialog" type="file" on-tap="addExistingAccount" style="display: none;">
+    <paper-button raised onclick="document.getElementById('fileDialog').click();" id="old-wallet">ADD EXISTING ACCOUNT</paper-button>
     <paper-button raised on-tap="backupWallet" id="key-backup">KEY BACKUP</paper-button>
     </div>
 

--- a/interface/elements/msc-profile-view/msc-profile-view.js
+++ b/interface/elements/msc-profile-view/msc-profile-view.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var os = require('os');
 var username1 = require('username');
+var copyFile = require('quickly-copy-file');
 Polymer({
   is: 'msc-profile-view',
   properties: {
@@ -69,7 +70,7 @@ Polymer({
       } else if (platform.includes("darwin")) {
         var pathOfKey = '/Users/' + username1 + '/Library/Musicoin/keystore';
       } else if (platform.includes("linux")){ //linux
-        var pathOfKey = '/' + username1 + '/.musicoin/keystore';
+        var pathOfKey = '/home/' + username1 + '/.musicoin/keystore';
       }
       var iconPath = 'file://' + nw.__dirname + '/favicon.png';
       var alert = {
@@ -83,6 +84,26 @@ Polymer({
   },
   handleSetCustomCoinbase: function() {
     this.$.setCoinbaseDialog.open();
+  },
+  addExistingAccount: function() {
+    document.querySelector('#fileDialog')
+  .addEventListener("change", function() {
+    var filePath = this.value;
+    var platform = os.platform();
+    username1().then(username1 => {
+      if (platform.includes("win32")) {
+        var pathOfKey = 'C:\\Users\\' + username1 + '\\AppData\\Roaming\\Musicoin\\keystore\\' + path.basename(filePath);
+      } else if (platform.includes("darwin")) {
+        var pathOfKey = '/Users/' + username1 + '/Library/Musicoin/keystore/' + path.basename(filePath);
+      } else if (platform.includes("linux")){ //linux
+        var pathOfKey = '/home/' + username1 + '/.musicoin/keystore/' + path.basename(filePath);
+      }
+    copyFile(filePath, pathOfKey, function(error) {
+      if (error) return console.error(error);
+       console.log('File was copied!')
+      });
+    });
+  });
   },
   showSendDialog: function(e) {
     this.$.sender.value = e.model.dataHost.dataHost.account.address;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node-localstorage": "^1.3.0",
     "nwjs-open-link-in-browser": "^1.0.3",
     "promise-queue": "^2.2.3",
+    "quickly-copy-file": "^1.0.0",
     "request": "^2.75.0",
     "reverse-line-reader": "^0.2.6",
     "serve-favicon": "~2.3.0",


### PR DESCRIPTION
This fixes issue #45 
Basically right now MDW only should dump add dialog that does nothing. This fix allows to import accounts that MDW uses itself. (UTC/JSON). Also reason that backup dialog didn't shows with `gui.Shell.showItemInFolder(pathOfKey);` under Linux was incorrect path, but not pcmanfm I use. This pull request fixes this too.