### PR TITLE
Fix broken backup id inside account dialog

### DIFF
--- a/interface/elements/msc-profile-view/msc-profile-view.html
+++ b/interface/elements/msc-profile-view/msc-profile-view.html
@@ -88,7 +88,7 @@
       <iron-icon icon="icons:backup" class=clickable title="Backup Account" on-tap="backupAccountFromDialog" style="display: block; margin: 0 auto; color: #cccccc; padding-top: 6px;"></iron-icon></p>
       <p style="text-align: center;">Show Private Key:
       <iron-icon icon="icons:lock-open" class=clickable title="Show Private Key" on-tap="unlockPrivateKeyFromAccount" style="display: block; margin: 0 auto; color: #cccccc; padding-top: 6px;"></iron-icon></p>
-      <input id=fileDialogBackupAccount-[[account.address]] type="file" nwdirectory style="display: none;">
+      <input id=fileDialogBackupAccount-{{userAccount}} type="file" nwdirectory style="display: none;">
       <div class="buttons-style top-buttons" style="display: block; margin: 0 auto;">
       <paper-button raised on-tap="approveRemoveAccount" id="approve-remove" style="right: 63%;">REMOVE</paper-button>
       <paper-button raised on-tap="showSendDialogFromAccount" id="send-funds">SEND FUNDS</paper-button>


### PR DESCRIPTION
We had no access to `[[account.address]]` here