### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,14 @@
   "name": "Musicoin-wallet",
   "version": "1.0.0",
   "license": "MIT",
-  "private": true,
+  "private": false,
+  "repository": { 
+    "type": "git", 
+    "url": "https://github.com/Musicoin/desktop.git" 
+  },
   "node-main": "./hub/msc.js",
   "main": "./interface/index.html",
+  "bugs": "https://github.com/Musicoin/desktop/issues",
   "window": {
     "frame": true,
     "toolbar": true,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "nw": "^0.29.3",
     "nwjs-builder": "^1.14.0",
     "snyk": "^1.71.0"
-  }
+  },
   "scripts": {
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,15 @@
     "qrcode": "^1.2.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
-    "snyk": "^1.70.2",
     "web3": "^0.20.6",
     "y18n": "^4.0.0",
     "zxcvbn": "^4.4.2"
   },
+  "devDependencies": {
+    "nw": "^0.29.3",
+    "nwjs-builder": "^1.14.0",
+    "snyk": "^1.71.0"
+  }
   "scripts": {
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect",


### PR DESCRIPTION
remove extra step from build by installing nw and nwjs-builder as a devDependency - snyk also is moved to devDeps. No global installs on the user's machine needed and no extra packages in the final product.