### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect",
+    "build:gmc": "git clone https://github.com/musicoin/go-musicoin gmc && cd gmc && make gmc"
     "test": "snyk test"
   },
   "snyk": true


### PR DESCRIPTION
Implements #215 - This still does assume Git and Go are both present. Until go-musicoin updates; we have to insist the person have go 1.9 or lower. The detection thinks 1.10 is 1.1. And no breaking change, so 2.x can't be allowed.