### PR TITLE
remove bower; use less yarn for ux and gmc crochet

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "exlcude": [
       "./*.md",
       "./local",
-      "./node_modules/bower",
-      "./node_modules/interface",
-      "./node_modules/musicoin-daemon",
       "./node_modules/nw",
       "./node_modules/nwjs-builder"
     ],
@@ -44,14 +41,11 @@
   "bugs": "https://github.com/Musicoin/desktop/issues",
   "dependencies": {
     "bluebird": "~3.5.1",
-    "bower": "~1.8.4",
     "ethereum-blockies": "github:ethereum/blockies",
     "ethers": "~3.0.17",
     "fs-extra": "~5.0.0",
     "fs-finder": "~1.8.1",
-    "interface": "github:musicoin/desktop-interface",
     "jsqr": "~1.0.4",
-    "musicoin-daemon": "github:musicoin/gmc-node-modules",
     "ntp-client": "~0.5.3",
     "nwjs-builder": "~1.14.0",
     "pngjs": "~3.3.2",
@@ -62,18 +56,21 @@
     "y18n": "~4.0.0",
     "zxcvbn": "~4.4.2"
   },
+  "devDependencies": {
+    "interface": "github:musicoin/desktop-interface",
+    "musicoin-daemon": "github:musicoin/gmc-node-modules"
+  },
   "engines": {
     "node": ">=8.0.0",
     "yarn": ">=1.6.0"
   },
   "scripts": {
-    "ux-build": "cd ./interface && ../node_modules/.bin/bower install && rm -f ./package.json",
-    "ux-copy": "mv ./node_modules/interface ./interface",
-    "gmc-copy": "mkdir -p ./bin/gmc && mv ./node_modules/musicoin-daemon/bin/gmc* ./bin/gmc/",
-    "preinstall": "rm -rf ./bin ./dist ./interface ./node_modules",
-    "postinstall": "yarn gmc-copy && yarn ux-copy && yarn ux-build",
+    "ux-copy": "cp -r ./node_modules/interface ./interface && rm -f ./interface/package.json",
+    "gmc-copy": "mkdir -p ./bin/gmc && cp -r ./node_modules/musicoin-daemon/bin/gmc* ./bin/gmc/",
+    "preinstall": "rm -rf ./interface ./bin",
+    "postinstall": "yarn gmc-copy && yarn ux-copy",
     "test": "rm -rf dist && ./node_modules/.bin/nwb nwbuild -v 0.30.0 --with-ffmpeg ./ -o dist/",
-    "debug": "./node_modules/.bin/nwb nwbuild -v 0.30.0 -r ./",
-    "dist": "yarn test && mv musicoin* dist"
+    "debug": "./node_modules/.bin/nwb nwbuild -v 0.30.0 -r ./"
   }
 }
+


### PR DESCRIPTION
remove depends upon bower; remove exclusion of bower install dir - it's now part of interface
remove ux-build step, done in ux module itself during install step
gmc rebuilds after install step; made reusable and devDepends
move both ux and gmc into devDependencies; can be reused from cache now

`yarn --link-duplicates && yarn debug` will show it off a bit.
![screen shot 2018-06-02 at 9 13 16 am](https://user-images.githubusercontent.com/36354460/40878385-39fe8304-6645-11e8-825c-5e083bfa3f06.png)

`yarn --link-duplicates && test` should build straight into ./dist.

result: faster build; WAY faster incremental rebuilds; smaller binary output
![screen shot 2018-06-02 at 9 09 07 am](https://user-images.githubusercontent.com/36354460/40878370-064063ca-6645-11e8-8053-ea74cbc8cd41.png)
![screen shot 2018-06-02 at 9 11 52 am](https://user-images.githubusercontent.com/36354460/40878373-0659ee76-6645-11e8-9b10-0442fff00b42.png)
![screen shot 2018-06-02 at 9 17 21 am](https://user-images.githubusercontent.com/36354460/40878419-d9eac896-6645-11e8-8bab-aa5bcdf4c036.png)


While the yarn linking and rebuilding modules takes longer now -- there just aren't any other steps other than the nwjs build or test that need be handled after that. The balance tips toward positive for these changes.