### PR TITLE
Replace Bittrex with Dove Wallet, remove Cryptopia

### DIFF
--- a/interface/elements/msc-profile-view/msc-profile-view.js
+++ b/interface/elements/msc-profile-view/msc-profile-view.js
@@ -1516,39 +1516,9 @@ markets.append(new nw.MenuItem({
 }));
 if (platform.includes("darwin")) {
   markets.append(new nw.MenuItem({
-    label: 'Bittrex: MUSIC/BTC',
+    label: 'Dove Wallet: MUSIC/BTC',
     click: function() {
-      gui.Window.open('https://bittrex.com/Market/Index?MarketName=BTC-MUSIC', {
-        position: 'center',
-        width: 1000,
-        height: 600
-      });
-    }
-  }));
-  markets.append(new nw.MenuItem({
-    label: 'Cryptopia: MUSIC/BTC',
-    click: function() {
-      gui.Window.open('https://www.cryptopia.co.nz/Exchange?market=MUSIC_BTC', {
-        position: 'center',
-        width: 1000,
-        height: 600
-      });
-    }
-  }));
-  markets.append(new nw.MenuItem({
-    label: 'Cryptopia: MUSIC/LTC',
-    click: function() {
-      gui.Window.open('https://www.cryptopia.co.nz/Exchange?market=MUSIC_LTC', {
-        position: 'center',
-        width: 1000,
-        height: 600
-      });
-    }
-  }));
-  markets.append(new nw.MenuItem({
-    label: 'Cryptopia: MUSIC/DOGE',
-    click: function() {
-      gui.Window.open('https://www.cryptopia.co.nz/Exchange?market=MUSIC_DOGE', {
+      gui.Window.open('https://dovewallet.com/trade/spot/music-btc', {
         position: 'center',
         width: 1000,
         height: 600
@@ -1557,27 +1527,9 @@ if (platform.includes("darwin")) {
   }));
 } else {
   markets.append(new nw.MenuItem({
-    label: 'Bittrex: MUSIC/BTC',
+    label: 'Dove Wallet: MUSIC/BTC',
     click: function() {
-      gui.Shell.openExternal('https://bittrex.com/Market/Index?MarketName=BTC-MUSIC');
-    }
-  }));
-  markets.append(new nw.MenuItem({
-    label: 'Cryptopia: MUSIC/BTC',
-    click: function() {
-      gui.Shell.openExternal('https://www.cryptopia.co.nz/Exchange?market=MUSIC_BTC');
-    }
-  }));
-  markets.append(new nw.MenuItem({
-    label: 'Cryptopia: MUSIC/LTC',
-    click: function() {
-      gui.Shell.openExternal('https://www.cryptopia.co.nz/Exchange?market=MUSIC_LTC');
-    }
-  }));
-  markets.append(new nw.MenuItem({
-    label: 'Cryptopia: MUSIC/DOGE',
-    click: function() {
-      gui.Shell.openExternal('https://www.cryptopia.co.nz/Exchange?market=MUSIC_DOGE');
+      gui.Shell.openExternal('https://dovewallet.com/trade/spot/music-btc');
     }
   }));
 }


### PR DESCRIPTION
This PR:

- Replaces `Bittrex Music/BTC` with `Dove Wallet Music/BTC`
- Removes `Cryptopia` completely

Before:
<img width="538" alt="image" src="https://user-images.githubusercontent.com/4966687/61725629-cd169200-ad78-11e9-9c30-d406e8f178cb.png">

After: (Running locally)
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/4966687/61726481-5e3a3880-ad7a-11e9-99d9-2fd7c88220e3.png">

Anyone have the bandwidth to codereview this PR?