### PR TITLE
Add Exchange Assets to the menu

### DIFF
--- a/interface/elements/msc-profile-view/msc-profile-view.js
+++ b/interface/elements/msc-profile-view/msc-profile-view.js
@@ -1525,12 +1525,28 @@ if (platform.includes("darwin")) {
       });
     }
   }));
+  markets.append(new nw.MenuItem({
+    label: 'Exchange Assets: MUSIC/BTC',
+    click: function() {
+      gui.Window.open('https://exchange-assets.com/en/?market=music_btc', {
+        position: 'center',
+        width: 1000,
+        height: 600
+      });      
+    }
+  }));
 } else {
   markets.append(new nw.MenuItem({
     label: 'Dove Wallet: MUSIC/BTC',
     click: function() {
       gui.Shell.openExternal('https://dovewallet.com/trade/spot/music-btc');
     }
+   })); 
+  markets.append(new nw.MenuItem({
+    label: 'Exchange Assets: MUSIC/BTC',
+    click: function() {
+      gui.Shell.openExternal('https://exchange-assets.com/en/?market=music_btc');
+    }                                 
   }));
 }
 menu.append(new nw.MenuItem({


### PR DESCRIPTION
According to Musicoin Medium page - Exchange Assets is a new page that does Musicoin/Bitcoin exchanges.

Added to the top menu bar:

<img width="541" alt="image" src="https://user-images.githubusercontent.com/4966687/61728825-9c395b80-ad7e-11e9-99c4-a629af1f1476.png">


Anyone have time to codereview this?
